### PR TITLE
Fix Fatal Error: Call to private method Symfony\Component\Routing\Loader\XmlFileLoader::getXmlErrors() ...

### DIFF
--- a/Routing/Loader/XmlFileLoader.php
+++ b/Routing/Loader/XmlFileLoader.php
@@ -78,4 +78,28 @@ class XmlFileLoader extends BaseXmlFileLoader
         }
         libxml_use_internal_errors($current);
     }
+    
+    /**
+     * Retrieves libxml errors and clears them.
+     *
+     * @return array An array of libxml error strings
+     */
+    private function getXmlErrors()
+    {
+        $errors = array();
+        foreach (libxml_get_errors() as $error) {
+            $errors[] = sprintf('[%s %s] %s (in %s - line %d, column %d)',
+                LIBXML_ERR_WARNING == $error->level ? 'WARNING' : 'ERROR',
+                $error->code,
+                trim($error->message),
+                $error->file ? $error->file : 'n/a',
+                $error->line,
+                $error->column
+            );
+        }
+
+        libxml_clear_errors();
+
+        return $errors;
+    }
 }


### PR DESCRIPTION
Function getXmlErrors is private in Symfony's XmlFileLoader so it produces Fatal Error: Call to private method Symfony\Component\Routing\Loader\XmlFileLoader::getXmlErrors() from context 'BeSimple\I18nRoutingBundle\Routing\Loader\XmlFileLoader'. 

To work correctly - it must be available in this overloaded class too.
