### PR TITLE
Added a composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,38 @@
+{
+    "name": "besimple/i18n-routing-bundle",
+    "type": "symfony-bundle",
+    "description": "Full routing internationalized on your Symfony2 project ",
+    "keywords": ["routing", "internationalisation", "Symfony2", "BeSimpleI18nRoutingBundle"],
+    "homepage": "https://github.com/BeSimple/BeSimpleI18nRoutingBundle",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Francis Besset",
+            "email": "francis.besset@gmail.com"
+        },
+        {
+            "name": "Christophe Coevoet",
+            "email": "stof@notk.org"
+        },
+        {
+            "name": "Benjamin Eberlei",
+            "email": "kontakt@beberlei.de"
+        },
+        {
+            "name": "BeSimple Community",
+            "homepage": "https://github.com/BeSimple/BeSimpleI18nRoutingBundle/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.2",
+        "symfony/framework-bundle": "2.*"
+    },
+    "suggest": {
+        "symfony/translator": ">=2.0",
+        "doctrine/dbal": ">=2.0"
+    },
+    "autoload": {
+        "psr-0": { "BeSimple\\I18nRoutingBundle": "" }
+    },
+    "target-dir": "BeSimple/I18nRoutingBundle"
+}


### PR DESCRIPTION
This adds the composer.json file for the bundle.

Please fix #14 and change the license in the composer.json file if you don't choose MIT.

Once it is merged, I suggest creating a tag before merging #6 (as the refactoring changes the XML namespace to keep things clean). And then probably another release for the refactored version (to avoid having to require `master-dev` to get it).

And of course, it should be submitted to [Packagist](http://packagist.org/)
