### PR TITLE
Added autoincrement on ID primary key for RoutingTranslationTable

### DIFF
--- a/Routing/Translator/DoctrineDBAL/SchemaListener.php
+++ b/Routing/Translator/DoctrineDBAL/SchemaListener.php
@@ -12,11 +12,11 @@ class SchemaListener
         $schema = $eventArgs->getSchema();
         $this->addRoutingTranslationsTable($schema);
     }
-    
+
     public function addRoutingTranslationsTable(Schema $schema)
     {
         $table = $schema->createTable('routing_translations');
-        $table->addColumn('id', 'integer');
+        $table->addColumn('id', 'integer', array('autoincrement' => true));
         $table->addColumn('route', 'string');
         $table->addColumn('locale', 'string');
         $table->addColumn('attribute', 'string');


### PR DESCRIPTION
When i try to addTranslation via DoctrineTranslator, i got this error.

``` sql
 SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '0' for key 'PRIMARY' 
```

The problem is that the RoutingTranslationTable's primary key isn't auto incremented.
