### PR TITLE
update installation instruction to recommend using composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,8 @@ When you create an I18N route and you go on it with your browser, the locale wil
 
 ## Installation
 
-```js
-//composer.json
-"require": {
-    //...
-    "besimple/i18n-routing-bundle": "dev-master"
-}
+```bash
+composer.phar require besimple/i18n-routing-bundle
 ```
 
 ```php


### PR DESCRIPTION
the extra benefit of this is that composer will select the latest stable release and require that or any newer version up to the next major version. currently that would be  `^2.3`