### PR TITLE
Annotation loader added (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ To get the diff between two versions, go to https://github.com/BeSimple/BeSimple
   * bugs #80 Set be_simple_i18n_routing.doctrine_dbal.connection_name parameter (boekkooi)
   * bugs #74 Exclude languaged (boekkooi)
   * bugs #77, #66 Added Symfony 3 support (boekkooi)
+  * feature #43 Added annotation loader support for Symfony 3.5 and greater (boekkooi)
   * feature #80 Introduced RouteNameInflector & RouteGenerator (boekkooi)
   * feature #80 Added strict route support (boekkooi)
   * feature #80 Implemented DI tests (boekkooi)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,27 @@ $collection->addCollection(
 return $collection;
 ```
 
+### Controller annotations
+ 
+Annotation loading is only supported for Symfony 2.5 and greater and needs to be enabled as followed.
+```YAML
+# app/config/config.yml
+be_simple_i18n_routing:
+    annotations: true
+```
+
+```PHP
+use BeSimple\I18nRoutingBundle\Routing\Annotation\I18nRoute;
+
+class NoPrefixController
+{
+    /**
+     * @I18nRoute({ "en": "/welcome", "fr": "/bienvenue", "de": "/willkommen" }, name="homepage")
+     */
+    public function indexAction() { }
+}
+```
+
 ### You can insert classic route in your routing
 
 #### Yaml routing file

--- a/src/DependencyInjection/BeSimpleI18nRoutingExtension.php
+++ b/src/DependencyInjection/BeSimpleI18nRoutingExtension.php
@@ -30,6 +30,7 @@ class BeSimpleI18nRoutingExtension extends Extension
         $this->configureLocales($config, $container);
         $this->configureAttributeTranslator($config, $container, $loader);
         $this->configureRouteNameInflector($config, $container);
+        $this->configureAnnotations($config, $container, $loader);
 
         $this->addClassesToCompile(array(
             'BeSimple\\I18nRoutingBundle\\Routing\\Router',
@@ -181,5 +182,21 @@ class BeSimpleI18nRoutingExtension extends Extension
         } catch (InvalidArgumentException $e) {
             // This happens when the alias is set to a external service in Symfony 2.3
         }
+    }
+
+    /**
+     * Configures the route annotations loader etc.
+     *
+     * @param array $config
+     * @param ContainerBuilder $container
+     * @param LoaderInterface $loader
+     */
+    private function configureAnnotations(array $config, ContainerBuilder $container, LoaderInterface $loader)
+    {
+        if (!isset($config['annotations']) || !$config['annotations']) {
+            return;
+        }
+
+        $loader->load('annotation.xml');
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -28,6 +28,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->booleanNode('annotations')->defaultFalse()->end()
                 ->scalarNode('route_name_inflector')->defaultValue('be_simple_i18n_routing.route_name_inflector.postfix')->end()
             ->end()
         ;

--- a/src/Resources/config/annotation.xml
+++ b/src/Resources/config/annotation.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="be_simple_i18n_routing.loader.annotation_dir" class="Symfony\Component\Routing\Loader\AnnotationDirectoryLoader" public="false">
+            <tag name="routing.loader" />
+            <argument type="service" id="file_locator" />
+            <argument type="service" id="be_simple_i18n_routing.loader.annotation_class" />
+        </service>
+
+        <service id="be_simple_i18n_routing.loader.annotation_file" class="Symfony\Component\Routing\Loader\AnnotationFileLoader" public="false">
+            <tag name="routing.loader" />
+            <argument type="service" id="file_locator" />
+            <argument type="service" id="be_simple_i18n_routing.loader.annotation_class" />
+        </service>
+
+        <service id="be_simple_i18n_routing.loader.annotation_class" class="BeSimple\I18nRoutingBundle\Routing\Loader\AnnotatedRouteControllerLoader" public="false">
+            <tag name="routing.loader" />
+            <argument type="service" id="annotation_reader" />
+            <argument type="service" id="be_simple_i18n_routing.route_generator" />
+        </service>
+    </services>
+</container>

--- a/src/Routing/Annotation/I18nRoute.php
+++ b/src/Routing/Annotation/I18nRoute.php
@@ -1,0 +1,146 @@
+<?php
+namespace BeSimple\I18nRoutingBundle\Routing\Annotation;
+
+/**
+ * Annotation class for @I18nRoute().
+ *
+ * @Annotation
+ * @Target({"CLASS", "METHOD"})
+ */
+class I18nRoute
+{
+    private $locales;
+    private $name;
+    private $requirements = array();
+    private $options = array();
+    private $defaults = array();
+    private $host;
+    private $methods = array();
+    private $schemes = array();
+    private $condition;
+
+    /**
+     * Constructor.
+     *
+     * @param array $data An array of key/value parameters.
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __construct(array $data)
+    {
+        if (isset($data['value'])) {
+            $data['locales'] = $data['value'];
+            unset($data['value']);
+        }
+
+        foreach ($data as $key => $value) {
+            $method = 'set'.str_replace('_', '', $key);
+            if (!method_exists($this, $method)) {
+                throw new \BadMethodCallException(sprintf('Unknown property "%s" on annotation "%s".', $key, get_class($this)));
+            }
+            $this->$method($value);
+        }
+    }
+
+    public function setLocales($locales)
+    {
+        $this->locales = $locales;
+    }
+
+    public function getLocales()
+    {
+        return $this->locales;
+    }
+
+    public function setHost($pattern)
+    {
+        $this->host = $pattern;
+    }
+
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setRequirements($requirements)
+    {
+        if (isset($requirements['_method'])) {
+            if (0 === count($this->methods)) {
+                $this->methods = explode('|', $requirements['_method']);
+            }
+        }
+
+        if (isset($requirements['_scheme'])) {
+            if (0 === count($this->schemes)) {
+                $this->schemes = explode('|', $requirements['_scheme']);
+            }
+        }
+
+        $this->requirements = $requirements;
+    }
+
+    public function getRequirements()
+    {
+        return $this->requirements;
+    }
+
+    public function setOptions($options)
+    {
+        $this->options = $options;
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    public function setDefaults($defaults)
+    {
+        $this->defaults = $defaults;
+    }
+
+    public function getDefaults()
+    {
+        return $this->defaults;
+    }
+
+    public function setSchemes($schemes)
+    {
+        $this->schemes = is_array($schemes) ? $schemes : array($schemes);
+    }
+
+    public function getSchemes()
+    {
+        return $this->schemes;
+    }
+
+    public function setMethods($methods)
+    {
+        $this->methods = is_array($methods) ? $methods : array($methods);
+    }
+
+    public function getMethods()
+    {
+        return $this->methods;
+    }
+
+    public function setCondition($condition)
+    {
+        $this->condition = $condition;
+    }
+
+    public function getCondition()
+    {
+        return $this->condition;
+    }
+}

--- a/src/Routing/Loader/AnnotatedRouteControllerLoader.php
+++ b/src/Routing/Loader/AnnotatedRouteControllerLoader.php
@@ -1,0 +1,209 @@
+<?php
+namespace BeSimple\I18nRoutingBundle\Routing\Loader;
+
+use BeSimple\I18nRoutingBundle\Routing\Exception\MissingLocaleException;
+use BeSimple\I18nRoutingBundle\Routing\Exception\MissingRouteLocaleException;
+use BeSimple\I18nRoutingBundle\Routing\RouteGenerator\I18nRouteGenerator;
+use BeSimple\I18nRoutingBundle\Routing\RouteGenerator\RouteGeneratorInterface;
+use Doctrine\Common\Annotations\Reader;
+use Symfony\Component\Routing\Loader\AnnotationClassLoader;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * This class is partially a copy of @see \Sensio\Bundle\FrameworkExtraBundle\Routing\AnnotatedRouteControllerLoader.
+ */
+class AnnotatedRouteControllerLoader extends AnnotationClassLoader
+{
+    /**
+     * @var RouteGeneratorInterface
+     */
+    private $routeGenerator;
+
+    public function __construct(Reader $reader, RouteGeneratorInterface $routeGenerator = null)
+    {
+        parent::__construct($reader);
+
+        $this->routeGenerator = $routeGenerator ?: new I18nRouteGenerator();
+        $this->setRouteAnnotationClass('BeSimple\\I18nRoutingBundle\\Routing\\Annotation\\I18nRoute');
+    }
+
+    protected function addRoute(RouteCollection $collection, $annot, $globals, \ReflectionClass $class, \ReflectionMethod $method)
+    {
+        /** @var \BeSimple\I18nRoutingBundle\Routing\Annotation\I18nRoute $annot */
+        $name = $annot->getName();
+        if (null === $name) {
+            $name = $this->getDefaultRouteName($class, $method);
+        }
+
+        $defaults = array_replace($globals['defaults'], $annot->getDefaults());
+        foreach ($method->getParameters() as $param) {
+            if (!isset($defaults[$param->getName()]) && $param->isDefaultValueAvailable()) {
+                $defaults[$param->getName()] = $param->getDefaultValue();
+            }
+        }
+        $requirements = array_replace($globals['requirements'], $annot->getRequirements());
+        $options = array_replace($globals['options'], $annot->getOptions());
+        $schemes = array_merge($globals['schemes'], $annot->getSchemes());
+        $methods = array_merge($globals['methods'], $annot->getMethods());
+
+        $host = $annot->getHost();
+        if (null === $host) {
+            $host = $globals['host'];
+        }
+
+        $condition = $annot->getCondition();
+        if (null === $condition && isset($globals['condition'])) {
+            $condition = $globals['condition'];
+        }
+
+        $path = '';
+        $localesWithPaths = $annot->getLocales();
+        if (is_scalar($localesWithPaths)) {
+            $routePath = $localesWithPaths;
+
+            if (!is_array($globals['locales'])) {
+                // This is a normal route
+                $path = $globals['locales'].$localesWithPaths;
+                $localesWithPaths = null;
+            } else {
+                // Global contains the locales
+                $localesWithPaths = array();
+                foreach ($globals['locales'] as $locale => $localePath) {
+                    $localesWithPaths[$locale] = $localePath.$routePath;
+                }
+            }
+        } elseif (is_array($localesWithPaths) && !empty($globals['locales'])) {
+            if (!is_array($globals['locales'])) {
+                // Global is a normal prefix
+                foreach ($localesWithPaths as $locale => $localePath) {
+                    $localesWithPaths[$locale] = $globals['locales'].$localePath;
+                }
+            } else {
+                foreach ($localesWithPaths as $locale => $localePath) {
+                    if (!isset($globals['locales'][$locale])) {
+                        throw new MissingLocaleException(sprintf(
+                            'Expected global configuration to contain %s for %s::%s',
+                            $locale,
+                            $class->getName(),
+                            $method->getName()
+                        ));
+                    }
+
+                    $localesWithPaths[$locale] = $globals['locales'][$locale].$localePath;
+                }
+            }
+        } elseif (!is_array($localesWithPaths)) {
+            throw new MissingRouteLocaleException(sprintf(
+                'Unsupported locales found for %s::%s',
+                $class->getName(),
+                $method->getName()
+            ));
+        }
+
+        $route = $this->createRoute($path, $defaults, $requirements, $options, $host, $schemes, $methods, $condition);
+
+        $this->configureRoute($route, $class, $method, $annot);
+
+        if ($localesWithPaths !== null) {
+            $collection->addCollection(
+                $this->routeGenerator->generateRoutes(
+                    $name,
+                    $localesWithPaths,
+                    $route
+                )
+            );
+        } else {
+            $collection->add($name, $route);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getGlobals(\ReflectionClass $class)
+    {
+        $globals = array(
+            'locales' => '',
+            'requirements' => array(),
+            'options' => array(),
+            'defaults' => array(),
+            'schemes' => array(),
+            'methods' => array(),
+            'host' => '',
+            'condition' => '',
+        );
+
+        /** @var \BeSimple\I18nRoutingBundle\Routing\Annotation\I18nRoute $annot */
+        if ($annot = $this->reader->getClassAnnotation($class, $this->routeAnnotationClass)) {
+            if (null !== $annot->getLocales()) {
+                $globals['locales'] = $annot->getLocales();
+            }
+
+            if (null !== $annot->getRequirements()) {
+                $globals['requirements'] = $annot->getRequirements();
+            }
+
+            if (null !== $annot->getOptions()) {
+                $globals['options'] = $annot->getOptions();
+            }
+
+            if (null !== $annot->getDefaults()) {
+                $globals['defaults'] = $annot->getDefaults();
+            }
+
+            if (null !== $annot->getSchemes()) {
+                $globals['schemes'] = $annot->getSchemes();
+            }
+
+            if (null !== $annot->getMethods()) {
+                $globals['methods'] = $annot->getMethods();
+            }
+
+            if (null !== $annot->getHost()) {
+                $globals['host'] = $annot->getHost();
+            }
+
+            if (null !== $annot->getCondition()) {
+                $globals['condition'] = $annot->getCondition();
+            }
+        }
+
+        return $globals;
+    }
+
+    /**
+     * Configures the _controller default parameter of a given Route instance.
+     *
+     * @param Route             $route  A route instance
+     * @param \ReflectionClass  $class  A ReflectionClass instance
+     * @param \ReflectionMethod $method A ReflectionClass method
+     * @param mixed             $annot  The annotation class instance
+     *
+     * @throws \LogicException When the service option is specified on a method
+     */
+    protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot)
+    {
+        $route->setDefault('_controller', $class->getName().'::'.$method->getName());
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @see \Sensio\Bundle\FrameworkExtraBundle\Routing\AnnotatedRouteControllerLoader::getDefaultRouteName
+     */
+    protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method)
+    {
+        $routeName = parent::getDefaultRouteName($class, $method);
+
+        return preg_replace(array(
+            '/(bundle|controller)_/',
+            '/action(_\d+)?$/',
+            '/__/',
+        ), array(
+            '_',
+            '\\1',
+            '_',
+        ), $routeName);
+    }
+}

--- a/tests/DependencyInjection/BeSimpleI18nRoutingExtensionTest.php
+++ b/tests/DependencyInjection/BeSimpleI18nRoutingExtensionTest.php
@@ -92,6 +92,20 @@ class BeSimpleI18nRoutingExtensionTest extends AbstractExtensionTestCase
     /**
      * @test
      */
+    public function loading_with_annotations()
+    {
+        $this->load(array(
+            'annotations' => true,
+        ));
+
+        $this->assertContainerBuilderHasService('be_simple_i18n_routing.loader.annotation_dir', 'Symfony\Component\Routing\Loader\AnnotationDirectoryLoader');
+        $this->assertContainerBuilderHasService('be_simple_i18n_routing.loader.annotation_file', 'Symfony\Component\Routing\Loader\AnnotationFileLoader');
+        $this->assertContainerBuilderHasService('be_simple_i18n_routing.loader.annotation_class', 'BeSimple\I18nRoutingBundle\Routing\Loader\AnnotatedRouteControllerLoader');
+    }
+
+    /**
+     * @test
+     */
     public function load_attribute_translator_service()
     {
         $this->load(array(

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -19,6 +19,7 @@ class ConfigurationTest extends AbstractConfigurationTestCase
         $this->assertProcessedConfigurationEquals(
             array(),
             array(
+                'annotations' => false,
                 'route_name_inflector' => 'be_simple_i18n_routing.route_name_inflector.postfix',
             )
         );

--- a/tests/Fixtures/Controller/MissingPrefixedLocalesController.php
+++ b/tests/Fixtures/Controller/MissingPrefixedLocalesController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace BeSimple\I18nRoutingBundle\Tests\Fixtures\Controller;
+
+use BeSimple\I18nRoutingBundle\Routing\Annotation\I18nRoute;
+
+/**
+ * @I18nRoute({ "en": "/en", "nl": "/nl" })
+ */
+class MissingPrefixedLocalesController
+{
+    /**
+     * @I18nRoute({ "en": "/new", "nl": "/nieuw", "fr": "/nouveau" }, name="foo")
+     */
+    public function newAction()
+    {
+    }
+}

--- a/tests/Fixtures/Controller/NoLocalesController.php
+++ b/tests/Fixtures/Controller/NoLocalesController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace BeSimple\I18nRoutingBundle\Tests\Fixtures\Controller;
+
+use BeSimple\I18nRoutingBundle\Routing\Annotation\I18nRoute;
+
+/**
+ * @I18nRoute("/base")
+ */
+class NoLocalesController
+{
+    /**
+     * @I18nRoute("/", name="index")
+     */
+    public function indexAction()
+    {
+    }
+
+    /**
+     * @I18nRoute("/new", name="new")
+     */
+    public function newAction()
+    {
+    }
+}

--- a/tests/Fixtures/Controller/NoPrefixController.php
+++ b/tests/Fixtures/Controller/NoPrefixController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BeSimple\I18nRoutingBundle\Tests\Fixtures\Controller;
+
+use BeSimple\I18nRoutingBundle\Routing\Annotation\I18nRoute;
+
+class NoPrefixController
+{
+    /**
+     * @I18nRoute({ "en": "/", "nl": "/nl/" })
+     */
+    public function indexAction()
+    {
+    }
+
+    /**
+     * @I18nRoute({ "en": "/new", "nl": "/nieuw" }, name="new_action")
+     */
+    public function newAction()
+    {
+    }
+}

--- a/tests/Fixtures/Controller/PlainPrefixController.php
+++ b/tests/Fixtures/Controller/PlainPrefixController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace BeSimple\I18nRoutingBundle\Tests\Fixtures\Controller;
+
+use BeSimple\I18nRoutingBundle\Routing\Annotation\I18nRoute;
+
+/**
+ * @I18nRoute("color")
+ */
+class PlainPrefixController
+{
+    /**
+     * @I18nRoute({"en": "/", "test": "/test"}, name="idx")
+     */
+    public function indexAction()
+    {
+    }
+
+    /**
+     * @I18nRoute("/plain", name="new")
+     */
+    public function newAction()
+    {
+    }
+}

--- a/tests/Fixtures/Controller/PrefixedLocalesController.php
+++ b/tests/Fixtures/Controller/PrefixedLocalesController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace BeSimple\I18nRoutingBundle\Tests\Fixtures\Controller;
+
+use BeSimple\I18nRoutingBundle\Routing\Annotation\I18nRoute;
+
+/**
+ * @I18nRoute({ "en": "/en", "nl": "/nl", "fr": "/fr" })
+ */
+class PrefixedLocalesController
+{
+    /**
+     * @I18nRoute("/", name="idx")
+     */
+    public function indexAction()
+    {
+    }
+
+    /**
+     * @I18nRoute({ "en": "/edit" }, name="edit")
+     */
+    public function editAction()
+    {
+    }
+
+    /**
+     * @I18nRoute({ "en": "/new", "nl": "/nieuw", "fr": "/nouveau" }, name="new")
+     */
+    public function newAction()
+    {
+    }
+}

--- a/tests/Routing/Annotation/I18nRouteTest.php
+++ b/tests/Routing/Annotation/I18nRouteTest.php
@@ -1,0 +1,41 @@
+<?php
+namespace BeSimple\I18nRoutingBundle\Tests\Routing;
+
+
+use BeSimple\I18nRoutingBundle\Routing\Annotation\I18nRoute;
+
+class I18nRouteTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testInvalidRouteParameter()
+    {
+        new I18nRoute(array('foo' => 'bar'));
+    }
+
+    /**
+     * @dataProvider getValidParameters
+     */
+    public function testRouteParameters($parameter, $value, $getter)
+    {
+        $route = new I18nRoute(array($parameter => $value));
+        $this->assertEquals($route->$getter(), $value);
+    }
+
+    public function getValidParameters()
+    {
+        return array(
+            array('value', '/Blog', 'getLocales'),
+            array('value', array('en' => '/BlogEn', 'nl' => '/Nl'), 'getLocales'),
+            array('requirements', array('locale' => 'en'), 'getRequirements'),
+            array('options', array('compiler_class' => 'RouteCompiler'), 'getOptions'),
+            array('name', 'blog_index', 'getName'),
+            array('defaults', array('_controller' => 'MyBlogBundle:Blog:index'), 'getDefaults'),
+            array('schemes', array('https'), 'getSchemes'),
+            array('methods', array('GET', 'POST'), 'getMethods'),
+            array('host', '{locale}.example.com', 'getHost'),
+            array('condition', 'context.getMethod() == "GET"', 'getCondition'),
+        );
+    }
+}

--- a/tests/Routing/Loader/AnnotatedRouteControllerLoaderTest.php
+++ b/tests/Routing/Loader/AnnotatedRouteControllerLoaderTest.php
@@ -1,0 +1,99 @@
+<?php
+namespace BeSimple\I18nRoutingBundle\Tests\Routing\Loader;
+
+use BeSimple\I18nRoutingBundle\Routing\Loader\AnnotatedRouteControllerLoader;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+
+class AnnotatedRouteControllerLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        if (!method_exists('Symfony\Component\Routing\Loader\AnnotationClassLoader', 'getGlobals')) {
+            self::markTestSkipped('Unsupported symfony version 2.5 or greater is required.');
+        }
+    }
+
+    public function testRoutesWithoutLocales()
+    {
+        $loader = new AnnotatedRouteControllerLoader(new AnnotationReader());
+        AnnotationRegistry::registerLoader('class_exists');
+
+        $rc = $loader->load('BeSimple\I18nRoutingBundle\Tests\Fixtures\Controller\NoLocalesController');
+
+        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $rc);
+        $this->assertContainsOnlyInstancesOf('Symfony\Component\Routing\Route', $rc);
+        $this->assertCount(2, $rc);
+
+        $this->assertEquals('/base/', $rc->get('index')->getPath());
+        $this->assertEquals('/base/new', $rc->get('new')->getPath());
+    }
+
+    public function testRoutesWithLocales()
+    {
+        $loader = new AnnotatedRouteControllerLoader(new AnnotationReader());
+        AnnotationRegistry::registerLoader('class_exists');
+
+        $rc = $loader->load('BeSimple\I18nRoutingBundle\Tests\Fixtures\Controller\NoPrefixController');
+
+        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $rc);
+        $this->assertContainsOnlyInstancesOf('Symfony\Component\Routing\Route', $rc);
+        $this->assertCount(4, $rc);
+
+        $this->assertEquals('/', $rc->get('besimple_i18nrouting_tests_fixtures_noprefix_index.en')->getPath());
+        $this->assertEquals('/nl/', $rc->get('besimple_i18nrouting_tests_fixtures_noprefix_index.nl')->getPath());
+        $this->assertEquals('/new', $rc->get('new_action.en')->getPath());
+        $this->assertEquals('/nieuw', $rc->get('new_action.nl')->getPath());
+    }
+
+    public function testRoutesWithPrefixedLocales()
+    {
+        $loader = new AnnotatedRouteControllerLoader(new AnnotationReader());
+        AnnotationRegistry::registerLoader('class_exists');
+
+        $rc = $loader->load('BeSimple\I18nRoutingBundle\Tests\Fixtures\Controller\PrefixedLocalesController');
+
+        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $rc);
+        $this->assertContainsOnlyInstancesOf('Symfony\Component\Routing\Route', $rc);
+        $this->assertCount(7, $rc);
+
+        $this->assertEquals('/en/', $rc->get('idx.en')->getPath());
+        $this->assertEquals('/nl/', $rc->get('idx.nl')->getPath());
+        $this->assertEquals('/fr/', $rc->get('idx.fr')->getPath());
+
+        $this->assertEquals('/en/edit', $rc->get('edit.en')->getPath());
+
+        $this->assertEquals('/en/new', $rc->get('new.en')->getPath());
+        $this->assertEquals('/nl/nieuw', $rc->get('new.nl')->getPath());
+        $this->assertEquals('/fr/nouveau', $rc->get('new.fr')->getPath());
+    }
+
+    public function testRoutesWithStringPrefix()
+    {
+        $loader = new AnnotatedRouteControllerLoader(new AnnotationReader());
+        AnnotationRegistry::registerLoader('class_exists');
+
+        $rc = $loader->load('BeSimple\I18nRoutingBundle\Tests\Fixtures\Controller\PlainPrefixController');
+
+        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $rc);
+        $this->assertContainsOnlyInstancesOf('Symfony\Component\Routing\Route', $rc);
+        $this->assertCount(3, $rc);
+
+        $this->assertEquals('/color/', $rc->get('idx.en')->getPath());
+        $this->assertEquals('/color/test', $rc->get('idx.test')->getPath());
+        $this->assertEquals('/color/plain', $rc->get('new')->getPath());
+    }
+
+    /**
+     * @expectedException \BeSimple\I18nRoutingBundle\Routing\Exception\MissingLocaleException
+     */
+    public function testRoutesMissingPrefixLocale()
+    {
+        $loader = new AnnotatedRouteControllerLoader(new AnnotationReader());
+        AnnotationRegistry::registerLoader('class_exists');
+
+        $loader->load('BeSimple\I18nRoutingBundle\Tests\Fixtures\Controller\MissingPrefixedLocalesController');
+    }
+}


### PR DESCRIPTION
Hi all,

This PR adds annotation loader support for Symfony 2.5 and up (and fixes issue #43). The reason for the version constraint is that we need the extra method separation added in Symfony 2.5.
Due to the constraint annotation loading is disabled by default to enable the annotation you must use the `annotations` configuration option.

I hope someone can give this a review :smile: 
Thanks in advance.

Cheers,
Warnar